### PR TITLE
Youtube playlist import

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,3 +1,7 @@
 {
-	"music-assist.import-youtube-playlist": "Import Youtube Playlist"
+	"music-assist.import-yt-playlist-nav-text": "Import YouTube Playlist",
+	"music-assist.import-yt-playlist-notes": "Enter a youtube playlist url or playlist ID below and click the import button next to it to get started.",
+	"music-assist.import-yt-playlist-btn-import": "Import",
+	"music-assist.import-yt-playlist-btn-submit": "Confirm",
+	"music-assist.import-yt-playlist-msg-invalidkey": "Please enter a valid youtube playlist url (with list in the querystring) or a playlist ID"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -2,6 +2,12 @@
 	"music-assist.import-yt-playlist-nav-text": "Import YouTube Playlist",
 	"music-assist.import-yt-playlist-notes": "Enter a youtube playlist url or playlist ID below and click the import button next to it to get started.",
 	"music-assist.import-yt-playlist-btn-import": "Import",
-	"music-assist.import-yt-playlist-btn-submit": "Confirm",
-	"music-assist.import-yt-playlist-msg-invalidkey": "Please enter a valid youtube playlist url (with list in the querystring) or a playlist ID"
+	"music-assist.import-yt-playlist-btn-submit": "Save",
+	"music-assist.import-yt-playlist-msg-already-working": "Playlist is currently being imported, please wait",
+	"music-assist.import-yt-playlist-msg-invalid-key": "Please enter a valid youtube playlist url (with list in the querystring) or a playlist ID",
+	"music-assist.import-yt-playlist-msg-error": "Error importing playlist - check the console for details",
+	"music-assist.import-yt-playlist-msg-key-not-found": "Playlist with key {playlistKey} does not exist - check the url or id and try again",
+	"music-assist.import-yt-playlist-msg-imported": "Playlist {playlistName} has been successfully imported",
+	"music-assist.import-yt-playlist-lbl-name": "Playlist name",
+	"music-assist.import-yt-playlist-lbl-volume": "Default volume"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,0 +1,3 @@
+{
+	"music-assist.import-youtube-playlist": "Import Youtube Playlist"
+}

--- a/module.json
+++ b/module.json
@@ -1,36 +1,44 @@
 {
-	"name": "music-assist",
-	"title": "MusicAssist",
-	"description": "A little helper which provides the ability to stream audio from remote sources (like youtube).",
-	"author": "temportalflux",
-	"version": "0.1.0",
-	"minimumCoreVersion": "0.5.3",
-	"compatibleCoreVersion": "0.5.5",
-	"esmodules": [
-		"./modules/main.js"
-	],
-	"styles": [
-		"./styles/music-assist.css"
-	],
-	"templates": [],
-	"url": "https://github.com/temportalflux/MusicAssist",
-	"manifest": "https://raw.githubusercontent.com/temportalflux/MusicAssist/master/module.json",
-	"download": "https://github.com/temportalflux/MusicAssist/releases/download/v0.1.0/MusicAssist-v0.1.0.zip",
-	"socket": true,
-	"debugBuildDirectory": "C:\\Users\\Dustin Yost\\AppData\\Local\\FoundryVTT\\Data\\modules\\",
-	"packageItems": [
-		"icons",
-		"lang",
-		"modules",
-		"packs",
-		"styles",
-		"templates",
-		"module.json",
-		"README.md"
-	],
-	"icons": [
-		"./icons/music-spell.png",
-		"./icons/music-spell.svg"
-	],
-	"scripts": []
+  "name": "music-assist",
+  "title": "MusicAssist",
+  "description": "A little helper which provides the ability to stream audio from remote sources (like youtube).",
+  "author": "temportalflux",
+  "version": "0.1.0",
+  "minimumCoreVersion": "0.5.3",
+  "compatibleCoreVersion": "0.5.5",
+  "esmodules": [
+    "./modules/main.js"
+  ],
+  "styles": [
+    "./styles/music-assist.css"
+  ],
+  "templates": [
+    "./templates/import-youtube-playlist.html"
+  ],
+  "url": "https://github.com/temportalflux/MusicAssist",
+  "manifest": "https://raw.githubusercontent.com/temportalflux/MusicAssist/master/module.json",
+  "download": "https://github.com/temportalflux/MusicAssist/releases/download/v0.1.0/MusicAssist-v0.1.0.zip",
+  "socket": true,
+  "debugBuildDirectory": "D:\\Documents\\FoundryVTT\\Data\\modules",
+  "packageItems": [
+    "icons",
+    "lang",
+    "modules",
+    "styles",
+    "templates",
+    "module.json",
+    "README.md"
+  ],
+  "languages": [
+    {
+      "lang": "en",
+      "name": "English",
+      "path": "lang/en.json"
+    }
+  ],
+  "icons": [
+    "./icons/music-spell.png",
+    "./icons/music-spell.svg"
+  ],
+  "scripts": []
 }

--- a/modules/YouTubeApiScraperService.js
+++ b/modules/YouTubeApiScraperService.js
@@ -1,0 +1,39 @@
+import * as MusicStreaming from './config.js';
+
+const PLAYLIST_MAX_SIZE = 200;
+
+export class YouTubeApiScraperService {
+	constructor() { }
+
+	async scrapeVideoNames(player) {
+		return new Promise(async (resolve) => {
+
+			var videoMap = [];
+			
+			for (let i=0; i < player.getPlaylist().length; i++) {
+				let data = player.getVideoData();
+				videoMap.push({
+					id: data.video_id,
+					title: data.title
+				});
+				
+				await this.getNextTrack(player);
+			}
+
+			resolve(videoMap);
+		});
+	}
+	
+	async getNextTrack(player) {
+		return new Promise((resolve) => {
+			player.addEventListener('onStateChange', event => {
+				if (event.data == -1) {
+				  event.target.removeEventListener('onStateChange');
+				  resolve(event.data);
+				}
+			});
+
+			player.nextVideo();
+		});
+	}
+}

--- a/modules/YouTubeApiScraperService.js
+++ b/modules/YouTubeApiScraperService.js
@@ -8,21 +8,15 @@ export class YouTubeApiScraperService {
 	async scrapeVideoNames(player) {
 		return new Promise(async (resolve, reject) => {
 
-			var videoMap = [];
-			for (let i=0; i < player.getPlaylist().length; i++) {
-				let data = player.getVideoData();
-				videoMap.push({
-					id: data.video_id,
-					title: data.title
-				});
+			let videoMap = [];
 
-				/*
-				* player.nextVideo() can time out sometimes, not sure why. So here, we put a timeout on it and retry up to 3 times, otherwise we throw.
+			 /*
+				* The player sometimes will do nothing (likely an API bug and onReady is being called too early) on the first track, not sure why. So here, we try three times to successfully get the right one before we start scraping. Otherwise we throw.
 				* This could probably be more elegant. The promise race works really nicely though.
-				*/
+			 */
 				for (let f = 0; f < 3; f++) {
 					try {
-						await this.getNextTrack(player);
+						await this.getTrack(player, 0);
 						break;
 					} catch(ex) {
 						MusicStreaming.log('getNextTrack timed out, retrying...');
@@ -31,13 +25,25 @@ export class YouTubeApiScraperService {
 						}
 					}
 				}
+
+			for (let i=0; i < player.getPlaylist().length; i++) {
+
+				await this.getTrack(player, i);
+
+				let data = player.getVideoData();
+				videoMap.push({
+					id: data.video_id,
+					title: data.title
+				});
+
+				
 			}
 
 			resolve(videoMap);
 		});
 	}
 	
-	async getNextTrack(player) {
+	async getTrack(player, idx) {
 		let playNextVideo = new Promise((resolve) => {
 			player.addEventListener('onStateChange', event => {
 				if (event.data == -1) {
@@ -45,7 +51,7 @@ export class YouTubeApiScraperService {
 				  resolve(event.data);
 				}
 			});
-			player.nextVideo();
+			player.playVideoAt(idx);
 		});
 
 		let timeout = new Promise((resolve, reject) => {

--- a/modules/YouTubeApiScraperService.js
+++ b/modules/YouTubeApiScraperService.js
@@ -8,10 +8,15 @@ export class YouTubeApiScraperService {
 	async scrapeVideoNames(player) {
 		return new Promise(async (resolve, reject) => {
 
+			if (!player.getPlaylist()) {
+				reject('Invalid Playlist');
+				return;
+			}
+
 			let videoMap = [];
 
 			 /*
-				* The player sometimes will do nothing (likely an API bug and onReady is being called too early) on the first track, not sure why. So here, we try three times to successfully get the right one before we start scraping. Otherwise we throw.
+				* The player sometimes will do nothing (likely an API bug and onReady is being called too early) on the first track. So here, we try three times to successfully get the right one before we start scraping. Otherwise we throw.
 				* This could probably be more elegant. The promise race works really nicely though.
 			 */
 				for (let f = 0; f < 3; f++) {
@@ -22,6 +27,7 @@ export class YouTubeApiScraperService {
 						MusicStreaming.log('getNextTrack timed out, retrying...');
 						if (f == 2) {
 							reject(ex);
+							return;
 						}
 					}
 				}
@@ -35,8 +41,6 @@ export class YouTubeApiScraperService {
 					id: data.video_id,
 					title: data.title
 				});
-
-				
 			}
 
 			resolve(videoMap);

--- a/modules/apis/YouTubePlaylistImportService.js
+++ b/modules/apis/YouTubePlaylistImportService.js
@@ -1,0 +1,110 @@
+import { getApi } from './index.js';
+import * as MusicStreaming from '../config.js';
+import { YouTubeApiScraperService } from '../YouTubeApiScraperService.js'
+
+
+//private consts & funcs
+const playerId = 'musicassist-playlist-player';
+let player;
+
+function createYoutubePlaylistPlayer(playlistId) {
+	$('body').append(`<div style=""><div id="${playerId}"></div></div>`);
+
+	return new YT.Player(playerId, {
+		width: '480px',
+		height: '270px',
+		playerVars: {
+      listType:'playlist',
+      list: playlistId
+    }
+	});
+}
+
+function cleanupPlayer() {
+	//Always clean up all traces of the player
+	if (player != null) {
+		player.destroy();
+		player = null;
+	}
+
+	$(`#${playerId}`).parent().remove();
+	MusicStreaming.log('Playlist player destroyed!');
+}
+
+export class YouTubePlaylistImportService {
+	constructor() { 
+		this.youTubeApiScraperService = new YouTubeApiScraperService();
+	}
+
+	extractPlaylistKey(playlistString) {
+		//YouTube url (any string with a list querystring var)
+		//No reliable regex lookbehind for all browsers yet, so we'll just get the first capture group instead
+		const urlRegEx = /list\=([a-zA-Z0-9_-]+)/
+		//Plain playlist key
+		const keyRegEx = /^[a-zA-Z0-9_-]+$/
+
+		if (!playlistString || playlistString.length === 0) {
+			return;
+		}
+
+		var matches = urlRegEx.exec(playlistString);
+		if (matches) {
+			return matches[1];
+		} else {
+			return playlistString.match(keyRegEx);
+		}
+	}
+	
+	async getPlaylistInfo(playlistKey) {
+		return new Promise((resolve, reject) => {
+
+			if (playlistKey == null) {
+				reject('Empty playlist key');
+				return;
+			}
+
+			/*
+			 *This is not too elegant as the YouTubeApi/YouTubePlayer classes are quite tightly coupled with playing sounds for Foundry, which we're not interested in doing.
+			 *We can get around this somewhat by creating our own YT.Player and ignoring the YouTubePlayer class altogether
+			 *Will probably need refactoring later.
+			*/
+			let api = getApi('youtube');
+			if (!api || !api.isReady()) {
+				//this should never really happen. The API is created during Foundry init.
+				MusicStreaming.log('Unable to extract playlist info - API not ready');
+				reject('API not ready');
+				return;
+			}	
+
+			if (player != null) {
+				reject('Player already exists');
+				return;
+			}
+
+			player = createYoutubePlaylistPlayer(playlistKey);
+
+			player.addEventListener('onReady', async (event) => {
+				try{
+					var videos = await this.youTubeApiScraperService.scrapeVideoNames(event.target);
+					resolve(videos);
+				}
+				catch (ex) {
+					MusicStreaming.log('Error scraping youtube iframe: ' + ex);
+					reject(ex);
+				}
+				finally {
+					cleanupPlayer();
+					return;
+				}
+			});
+
+			player.addEventListener('onError', event => {
+				MusicStreaming.log('Playlist player error!');
+				MusicStreaming.log('YT Player errored with code: ' + event.data);
+				reject('YT player error: ' + event.data);
+				cleanupPlayer();
+				return;
+			});
+		});
+	}
+}

--- a/modules/display/YoutubePlaylistImportApp.js
+++ b/modules/display/YoutubePlaylistImportApp.js
@@ -1,19 +1,27 @@
-export class YoutubePlaylistImportApp extends FormApplication {
+import { YouTubePlaylistImportService } from '../apis/YouTubePlaylistImportService.js';
+
+export class YouTubePlaylistImportApp extends FormApplication {
 	constructor(object = {}, options = null) {
     super(object, options);
+    this.importService = new YouTubePlaylistImportService();
+    this.playlistItems = [];
   }
 
-	activateListeners(html) {
-  //Todo setup form listeners
-	}
-
-	static get defaultOptions() {
+  static get defaultOptions() {
     const options = super.defaultOptions;
     options.template = 'modules/music-assist/templates/import-youtube-playlist.html';
-		options.title = game.i18n.localize('music-assist.import-youtube-playlist');
+		options.title = game.i18n.localize('music-assist.import-yt-playlist-nav-text');
 		
     return options;
   }
+
+	activateListeners(html) {
+    super.activateListeners(html);
+
+    html.find('button[id="music-assist-yt-import-btn-import"]').click(() => {
+      this._onImportPlaylist(html.find('input[id="music-assist-yt-import-url-text"]')[0].value);
+    });
+	}
 
 	getData() {
     return {
@@ -21,4 +29,14 @@ export class YoutubePlaylistImportApp extends FormApplication {
     };
   }
 
+  async _onImportPlaylist(playlistStr) {
+    let key = this.importService.extractPlaylistKey(playlistStr);
+    if (!key) {
+      ui.notifications.error(game.i18n.localize('music-assist.import-yt-playlist-msg-invalidkey'));
+      return;
+    }
+
+    this.playlistItems = await this.importService.getPlaylistInfo(key);
+
+  }
 }

--- a/modules/display/YoutubePlaylistImportApp.js
+++ b/modules/display/YoutubePlaylistImportApp.js
@@ -2,6 +2,10 @@ import { YouTubePlaylistImportService } from '../apis/YouTubePlaylistImportServi
 
 export class YouTubePlaylistImportApp extends FormApplication {
 	constructor(object = {}, options = null) {
+    if (!options) {
+      options = {};
+    }
+    options.height = 'auto';
     super(object, options);
     this.importService = new YouTubePlaylistImportService();
     this.playlistItems = [];
@@ -18,14 +22,18 @@ export class YouTubePlaylistImportApp extends FormApplication {
 	activateListeners(html) {
     super.activateListeners(html);
 
-    html.find('button[id="music-assist-yt-import-btn-import"]').click(() => {
-      this._onImportPlaylist(html.find('input[id="music-assist-yt-import-url-text"]')[0].value);
+    html.find('button[id="music-assist-yt-import-btn-import"]').click(async () => {
+      let spinner = html.find('div.playlist-import-loading-spinner')[0];
+      spinner.classList.remove('hidden');
+      await this._onImportPlaylist(html.find('input[id="music-assist-yt-import-url-text"]')[0].value);
+      this.render(false);
+      this.setPosition();
     });
 	}
 
 	getData() {
     return {
-        myVar: 'This is a test var'
+        playlistItems: this.playlistItems
     };
   }
 

--- a/modules/display/YoutubePlaylistImportApp.js
+++ b/modules/display/YoutubePlaylistImportApp.js
@@ -1,0 +1,24 @@
+export class YoutubePlaylistImportApp extends FormApplication {
+	constructor(object = {}, options = null) {
+    super(object, options);
+  }
+
+	activateListeners(html) {
+  //Todo setup form listeners
+	}
+
+	static get defaultOptions() {
+    const options = super.defaultOptions;
+    options.template = 'modules/music-assist/templates/import-youtube-playlist.html';
+		options.title = game.i18n.localize('music-assist.import-youtube-playlist');
+		
+    return options;
+  }
+
+	getData() {
+    return {
+        myVar: 'This is a test var'
+    };
+  }
+
+}

--- a/modules/main.js
+++ b/modules/main.js
@@ -1,7 +1,19 @@
-import { initializeApis } from './apis/index.js'
+import { initializeApis } from './apis/index.js';
+import { preloadTemplates } from './preloadTemplates.js';
+import { YoutubePlaylistImportApp  } from './display/YoutubePlaylistImportApp.js';
 import './patches/index.js';
 
 Hooks.on("init", async () =>
 {
 	await initializeApis();
+
+	await preloadTemplates();
+});
+
+Hooks.on("renderPlaylistDirectory", (app, html, data) => {
+	const importButton = $(`<button class="import-yt-playlist">${game.i18n.localize('music-assist.import-youtube-playlist')}</button>`);
+	html.find(".directory-footer").append(importButton);
+	importButton.click((ev) => {
+		new YoutubePlaylistImportApp().render(true);
+	});
 });

--- a/modules/main.js
+++ b/modules/main.js
@@ -1,6 +1,6 @@
 import { initializeApis } from './apis/index.js';
 import { preloadTemplates } from './preloadTemplates.js';
-import { YoutubePlaylistImportApp  } from './display/YoutubePlaylistImportApp.js';
+import { YouTubePlaylistImportApp  } from './display/YouTubePlaylistImportApp.js';
 import './patches/index.js';
 
 Hooks.on("init", async () =>
@@ -11,9 +11,11 @@ Hooks.on("init", async () =>
 });
 
 Hooks.on("renderPlaylistDirectory", (app, html, data) => {
-	const importButton = $(`<button class="import-yt-playlist">${game.i18n.localize('music-assist.import-youtube-playlist')}</button>`);
-	html.find(".directory-footer").append(importButton);
-	importButton.click((ev) => {
-		new YoutubePlaylistImportApp().render(true);
-	});
+	if (game.user.isGM) {
+			const importButton = $(`<button class="import-yt-playlist"><i class="fab fa-youtube"></i>${game.i18n.localize('music-assist.import-yt-playlist-nav-text')}</button>`);
+			html.find(".directory-footer").append(importButton);
+			importButton.click((ev) => {
+				new YouTubePlaylistImportApp().render(true);
+		});	
+	}
 });

--- a/modules/patches/PlaylistSoundConfig.js
+++ b/modules/patches/PlaylistSoundConfig.js
@@ -8,7 +8,7 @@ Hooks.on('renderPlaylistSoundConfig', (cfg, html, data) =>
 
 overrideFunc(PlaylistSoundConfig.prototype, '_updateObject', function(super_updateObject, evt, formData, etc)
 {
-	if (!game.user.isGM) throw "You do not have the ability to configure an AmbientSound object.";
+	if (!game.user.isGM) throw "You do not have the ability to configure an PlaylistSound object.";
 
 	if (!formData.streamed)
 	{

--- a/modules/preloadTemplates.js
+++ b/modules/preloadTemplates.js
@@ -1,0 +1,7 @@
+export const preloadTemplates = async function() {
+	const templatePaths = [
+			'modules/music-assist/templates/import-youtube-playlist.html'
+	];
+
+	return loadTemplates(templatePaths);
+}

--- a/styles/music-assist.css
+++ b/styles/music-assist.css
@@ -6,8 +6,8 @@
 .playlist-import-container {
 	overflow: auto;
 	max-height: 300px;
-	margin-top: 20px;
-	margin-bottom: 20px;
+	margin-top: 10px;
+	margin-bottom: 10px;
 }
 
 .playlist-import-loading-spinner {
@@ -19,6 +19,8 @@
 	height: 40px;
 	animation: spin 2s linear infinite;
 	margin: auto;
+	margin-top: 10px;
+	margin-bottom: 10px;
 }
 
 @keyframes spin {
@@ -32,5 +34,5 @@
 
 /* bug in foundry's styling obscures ordered lists larger than 100. */
 .playlist-import-container > ol {
-	 margin: 0 0 0 2.25em;
+	 margin-left: 1.75em;
 }

--- a/styles/music-assist.css
+++ b/styles/music-assist.css
@@ -2,3 +2,35 @@
 	flex-basis: 100%;
 	margin-top: 3px;
 }
+
+.playlist-import-container {
+	overflow: auto;
+	max-height: 300px;
+	margin-top: 20px;
+	margin-bottom: 20px;
+}
+
+.playlist-import-loading-spinner {
+  border: 8px solid #f3f3f3;
+	border-top: 8px solid #2b2c41;
+	border-bottom: 8px solid #2b2c41;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+	animation: spin 2s linear infinite;
+	margin: auto;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.hidden {
+	display: none;
+}
+
+/* bug in foundry's styling obscures ordered lists larger than 100. */
+.playlist-import-container > ol {
+	 margin: 0 0 0 2.25em;
+}

--- a/styles/music-assist.css
+++ b/styles/music-assist.css
@@ -11,12 +11,12 @@
 }
 
 .playlist-import-loading-spinner {
-  border: 8px solid #f3f3f3;
+	border: 8px solid #f3f3f3;
 	border-top: 8px solid #2b2c41;
 	border-bottom: 8px solid #2b2c41;
-  border-radius: 50%;
-  width: 40px;
-  height: 40px;
+	border-radius: 50%;
+	width: 40px;
+	height: 40px;
 	animation: spin 2s linear infinite;
 	margin: auto;
 }

--- a/styles/music-assist.css
+++ b/styles/music-assist.css
@@ -1,0 +1,4 @@
+.sidebar-tab > .directory-footer > button.import-yt-playlist {
+	flex-basis: 100%;
+	margin-top: 3px;
+}

--- a/templates/import-youtube-playlist.html
+++ b/templates/import-youtube-playlist.html
@@ -12,7 +12,7 @@
 	{{#if playlistItems}}
 	<div class="form-group">
 		<label for="music-assist-yt-import-playlist-name">{{localize 'music-assist.import-yt-playlist-lbl-name'}}:</label>
-		<input type="text" id="music-assist-yt-import-playlist-name" name="playlistname">
+		<input type="text" id="music-assist-yt-import-playlist-name" name="playlistname" required>
 	</div>
 	<div class="form-group">
 		<label for="music-assist-yt-import-playlist-volume">{{localize 'music-assist.import-yt-playlist-lbl-volume'}}:</label>

--- a/templates/import-youtube-playlist.html
+++ b/templates/import-youtube-playlist.html
@@ -2,13 +2,23 @@
 	<p class="notes">{{localize 'music-assist.import-yt-playlist-notes'}}</p>
 	<div class="form-group">
 		<div class="form-fields">
-			<input id="music-assist-yt-import-url-text" type="text" placeholder="https://www.youtube.com/playlist?list=PLccmC0-jXVkiQF1uMehdwqSlpXafNAe_e">
-			<button id="music-assist-yt-import-btn-import" type="button" name="import"><i class="fas fa-file-import"></i></button>
+			<input type="text" id="music-assist-yt-import-url-text" placeholder="https://www.youtube.com/playlist?list=PLccmC0-jXVkiQF1uMehdwqSlpXafNAe_e">
+			<button type="button" id="music-assist-yt-import-btn-import" name="import"><i class="fas fa-file-import"></i></button>
 		</div>
 	</div>
-	<div class="playlist-import-loading-spinner hidden"></div>
+	{{#if working}}
+	<div class="playlist-import-loading-spinner"></div>
+	{{/if}}
+	{{#if playlistItems}}
+	<div class="form-group">
+		<label for="music-assist-yt-import-playlist-name">{{localize 'music-assist.import-yt-playlist-lbl-name'}}:</label>
+		<input type="text" id="music-assist-yt-import-playlist-name" name="playlistname">
+	</div>
+	<div class="form-group">
+		<label for="music-assist-yt-import-playlist-volume">{{localize 'music-assist.import-yt-playlist-lbl-volume'}}:</label>
+		<input type="range" class="sound-volume" id="music-assist-yt-import-playlist-volume" val="0.5" min="0" max="1" step="0.05" name="playlistvolume">
+	</div>
 	<section class="playlist-import-container">
-		{{#if playlistItems}}
 		<ol>
 			{{#each playlistItems}}
 			<li>
@@ -16,7 +26,9 @@
 			</li>
 			{{/each}}
 		</ol>
-		{{/if}}
 	</section>
-	<button id="music-assist-yt-import-btn-confirm" type="submit" name="submit" disabled><i class="fas fa-check"></i>{{localize 'music-assist.import-yt-playlist-btn-submit'}}</button>
+	{{/if}}
+	<button type="submit" id="music-assist-yt-import-btn-confirm" name="submit" {{#unless playlistItems}}disabled{{/unless}}>
+		<i class="fas fa-file-download"></i>{{localize 'music-assist.import-yt-playlist-btn-submit'}}
+	</button>
 </form>

--- a/templates/import-youtube-playlist.html
+++ b/templates/import-youtube-playlist.html
@@ -1,0 +1,5 @@
+<form autocomplete="off">
+	<div>
+		Hello World: {{myVar}}
+	</div>
+</form>

--- a/templates/import-youtube-playlist.html
+++ b/templates/import-youtube-playlist.html
@@ -1,5 +1,26 @@
-<form autocomplete="off">
-	<div>
-		Hello World: {{myVar}}
+<form id="playlist-yt-import" autocomplete="off" onsubmit="event.preventDefault();">
+	<p class="notes">{{localize 'music-assist.import-yt-playlist-notes'}}</p>
+	<div class="form-group">
+		<div class="form-fields">
+			<input id="music-assist-yt-import-url-text" type="text" placeholder="https://www.youtube.com/playlist?list=PLccmC0-jXVkiQF1uMehdwqSlpXafNAe_e">
+			<button id="music-assist-yt-import-btn-import" type="button" name="import"><i class="fas fa-file-import"></i></button>
+		</div>
 	</div>
+	<section>
+		<ol>
+			<li>
+				song 1 - 12315679
+			</li>
+			<li>
+				song 2 - 12315676
+			</li>
+			<li>
+				song 3 - 12315674
+			</li>
+			<li>
+				song 4 - 12315671
+			</li>
+		</ol>
+	</section>
+	<button id="music-assist-yt-import-btn-confirm" type="submit" name="submit" disabled><i class="fas fa-check"></i>{{localize 'music-assist.import-yt-playlist-btn-submit'}}</button>
 </form>

--- a/templates/import-youtube-playlist.html
+++ b/templates/import-youtube-playlist.html
@@ -6,21 +6,17 @@
 			<button id="music-assist-yt-import-btn-import" type="button" name="import"><i class="fas fa-file-import"></i></button>
 		</div>
 	</div>
-	<section>
+	<div class="playlist-import-loading-spinner hidden"></div>
+	<section class="playlist-import-container">
+		{{#if playlistItems}}
 		<ol>
+			{{#each playlistItems}}
 			<li>
-				song 1 - 12315679
+				{{this.title}}
 			</li>
-			<li>
-				song 2 - 12315676
-			</li>
-			<li>
-				song 3 - 12315674
-			</li>
-			<li>
-				song 4 - 12315671
-			</li>
+			{{/each}}
 		</ol>
+		{{/if}}
 	</section>
 	<button id="music-assist-yt-import-btn-confirm" type="submit" name="submit" disabled><i class="fas fa-check"></i>{{localize 'music-assist.import-yt-playlist-btn-submit'}}</button>
 </form>


### PR DESCRIPTION
Implements #4 

Exploits the YT iframe API to scrape video information and create a streamable playlist.

Might need some testing, but I've tried to break it as much as I can and have fixed anything that has cropped up.

One limitation of this approach is that the youtube playlist name is not actually scrapable as there is no reference to it in the API that I can see. The user can just add this themself.

Usage:

GMs will see an 'Import Youtube Playlist' button on the Sounds tab of Foundry
![image](https://user-images.githubusercontent.com/1485053/86513050-f94ae780-bdfe-11ea-91da-ada31135f112.png)

Clicking this creates an app that facilitates the import
![image](https://user-images.githubusercontent.com/1485053/86513082-25feff00-bdff-11ea-85f7-6565700a8b74.png)

After entering a url or playlistId and clicking the import button, the app will fire off some api calls and scrape the results, forming them into a list. From there, the user can adjust default volume and give the playlist a name. The scraping process can take a few seconds for a long playlist.
![image](https://user-images.githubusercontent.com/1485053/86513185-13d19080-be00-11ea-9d35-9401d655c738.png)

Clicking save will generate the playlist and add the tracks to it
![image](https://user-images.githubusercontent.com/1485053/86513223-54c9a500-be00-11ea-91df-9e9ac7216dc9.png)